### PR TITLE
Make examples homescreen text configurable

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -95,7 +95,13 @@ class OVOSHomescreenSkill(MycroftSkill):
             LOG.warning("Requested update before skill_info API loaded")
             self._load_skill_apis()
         if self.skill_info_api:
-            self.gui['skill_examples'] = {"examples": self.skill_info_api.skill_info_examples()}
+            prefix = self.settings.get("examples_prefix", "Ask Me,")
+            if prefix:
+                examples = [' '.join((prefix, e)) for e in
+                            self.skill_info_api.skill_info_examples()]
+            else:
+                examples = self.skill_info_api.skill_info_examples()
+            self.gui['skill_examples'] = {"examples": examples}
         else:
             LOG.warning("No skill_info_api, skipping update")
 

--- a/settingsmeta.yml
+++ b/settingsmeta.yml
@@ -20,3 +20,7 @@ skillMetadata:
           type: text
           label: Wallpaper
           value: default.jpg
+        - name: examples_prefix
+          type: text
+          label: Examples Prefix
+          value: "Ask Me,"

--- a/ui/idle.qml
+++ b/ui/idle.qml
@@ -483,7 +483,7 @@ Mycroft.CardDelegate {
                         wrapMode: Text.WordWrap
                         font.weight: Font.DemiBold
                         property string entry
-                        text: '<i>“Ask Me, ' + entry + '”</i>'
+                        text: '<i>“' + entry + '”</i>'
                         color: "white"
                         layer.enabled: true
                         layer.effect: DropShadow {


### PR DESCRIPTION
Make string prefix for examples configurable in skill settings with default value for backwards-compat.
https://github.com/OpenVoiceOS/skill-ovos-homescreen/issues/4